### PR TITLE
Accept attributes, use ssl

### DIFF
--- a/chef/config.go
+++ b/chef/config.go
@@ -20,7 +20,7 @@ func (c *Config) Client() (*chefGo.Client, error) {
 		Name:    c.Name,
 		Key:     string(key),
 		BaseURL: c.BaseURL,
-		SkipSSL: true,
+		SkipSSL: false,
 	}
 
 	return chefGo.NewClient(&config)

--- a/main.go
+++ b/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-  "github.com/rsyabuta/terraform-chef-provider/chef"
-  "github.com/hashicorp/terraform/plugin"
+	"github.com/hashicorp/terraform/plugin"
+	"github.com/shopify/terraform-provider-chef/chef"
 )
 
 func main() {
-  plugin.Serve(&plugin.ServeOpts{
-    ProviderFunc: chef.Provider,
-  })
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: chef.Provider,
+	})
 }


### PR DESCRIPTION
@thegedge @wvanbergen @graemej @xthexder for review

cc @dwradcliffe 
# What the fuck is this

Well, unfortunately there's a couple of issues with terraform's chef provisioner:
- It cannot set the runlist, because of our custom chef workflow
  - We do not allow nodes to update their own runlist for security reasons. If they could, then any compromised node could drain our data bags of all secrets.
- On deleting an aws instance, there's no way to clean up the chef node or client, because terraform doesn't have a concept of lifecycles for provisioners (there are a couple of issues we filed today to do with this)

This forks an existing plugin that someone else made, presumably because they had similar issues.
## How does it work?

We create a chef node as a **separate resource** that the instance depends on. This will make it so that if the chef node is deleted, the node will also be deleted. This takes care of the 'cleanup' problem.

The instance resource is responsible for making sure the node gets bootstrapped (it takes 3 provisioner blocks, which makes me a :cry: :panda_face: )

The chef node block is responsible for all things chef. This is were you actually change the nodes environment and run list, and set the node name.
# What have I changed here

I've:
- Forced SSL verify to true, because anything else is insane.
- I've added support for managing node attributes
  - We use the 'normal' attribute, which seems to be the most applicable to our use case here, as it will leave the attribute set between chef runs.
- Renamed it from terraform-chef-provider to terraform-provider-chef, because that's the correct naming scheme for a terraform plugin. I've also pointed it at our fork
# How do I use this?

I want to make this our own terraform module, because some quirks in our chef workflow make this a bit of a pain and not very DRY.

Anyways, below is the minimum(ish) code to use this:

vars.tf:

```
variable "region" {
  default = "us-east-1"
  description = "AWS Region to use"
}

variable "chefuser" {
  default = "daleh"
  description = "Username of a chef administrator client"
}

variable "chefkey" {
  default = "/home/dale.hamel/.chef/configs/shopify/client.pem"
  description = "Path to the client key for chef administrator user"
}

variable "chefurl" {
  default = "https://chef.shopify.com/"
  description = "Location of the chef server"
}

provider "aws" {
  region = "${var.region}"
}

provider "chef" {
  client_name = "${var.chefuser}"
  key = "${var.chefkey}"
  server_url = "${var.chefurl}"
}
```

main.tf:

```
resource "aws_instance" "test_node" {
  ami = "ami-5f6a8034" // us-east-1 AMI 
  instance_type = "c3.large"
  key_name = "dale.hamel" // FIXME
  tags {
    Name = "${chef_node.test_node.name}"
  }

  connection {
    user = "ubuntu"
    agent = "true"
  }

  provisioner "remote-exec" {
    inline = [ 
    "sudo mkdir -p /etc/chef",
    "sudo touch /etc/chef/bootstrapping"
    ]   
  }

  provisioner "chef" {
    node_name = "${chef_node.test_node.name}"
    run_list = []
    server_url = "${var.chefurl}"
    validation_client_name = "${var.chefuser}"
    validation_key_path = "${var.chefkey}"
    version = "12.0.3"
  }

  provisioner "remote-exec" {
    inline = [ 
    "sudo chef-client",
    ]   
  }

}

resource "chef_node" "test_node" {
  name = "testnode.${var.region}.aws.shopify.com"
  run_list = [ "role[location--ec2]" ]
  attributes = { 
    "foo" = "bar"
  }
}

```
