### PR TITLE
Fixes two issues when reading from chef server.

### DIFF
--- a/chef/resource_chef_node.go
+++ b/chef/resource_chef_node.go
@@ -113,7 +113,14 @@ func resourceChefNodeRead(d *schema.ResourceData, meta interface{}) error {
 
 	node, err := client.Nodes.Get(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error reading chef node: %s", err)
+		if err.(*chefGo.ErrorResponse).Response.StatusCode == 404 {
+			// If the node doesn't exist, that's okay! Set the Id to an empty string
+			// and terraform will happily recreate it on the next apply
+			d.SetId("")
+			return nil
+		} else {
+			return fmt.Errorf("Error reading chef node: %s", err)
+		}
 	}
 
 	schema_run_list := make([]interface{}, 0)


### PR DESCRIPTION
1. If the node doesn't exist, we shouldn't fail but indicate to terraform that the node no longer exists.
2. Actually reading the node's normal attributes. This is useful if the state in the chef server diverges from what we have in our Terraform state file (e.g., someone manually modifies a node's normal attributes)

@Shopify/cloud 
